### PR TITLE
Rename namespace to Addresses API and uncomment Handler test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,13 +54,13 @@ commands:
       - run:
           name: Build lambda
           command: |
-            cd ./AddressDataPipeline/
+            cd ./AddressesDataPipeline/
             chmod +x ./build.sh
             ./build.sh
       - run:
           name: Deploy lambda
           command: |
-            cd ./AddressDataPipeline/
+            cd ./AddressesDataPipeline/
             sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ resources*
 .serverless*
 .vs*
 Properties
+.idea/*

--- a/AddressesDataPipeline.Tests/DatabaseTests.cs
+++ b/AddressesDataPipeline.Tests/DatabaseTests.cs
@@ -4,9 +4,9 @@ using FluentAssertions;
 using Moq;
 using Npgsql;
 using NUnit.Framework;
-using AddressDataPipeline.Database;
+using AddressesDataPipeline.Database;
 
-namespace AddressDataPipeline.Tests
+namespace AddressesDataPipeline.Tests
 {
     [TestFixture]
     public class DatabaseTests

--- a/AddressesDataPipeline.Tests/GlobalSuppressions.cs
+++ b/AddressesDataPipeline.Tests/GlobalSuppressions.cs
@@ -5,4 +5,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member", Target = "~M:AddressDataPipeline.Tests.DatabaseTests.CountRows~System.Int64")]
+[assembly: SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>", Scope = "member", Target = "~M:AddressesDataPipeline.Tests.DatabaseTests.CountRows~System.Int64")]

--- a/AddressesDataPipeline.Tests/Handler.cs
+++ b/AddressesDataPipeline.Tests/Handler.cs
@@ -16,37 +16,39 @@ namespace AddressesDataPipeline.Tests
     [TestFixture]
     public class HandlerTest : DatabaseTests
     {
-        //[Test]
-        //public void CanLoadACsvIntoTheDatabase()
-        //{
-        //    var mockDatabaseActions = new Mock<IDatabaseActions>();
-        //    var handler = new Handler(mockDatabaseActions.Object);
-        //    var tableName = "myTable";
+        [Test]
+        public void CanLoadACsvIntoTheDatabase()
+        {
+            var mockDatabaseActions = new Mock<IDatabaseActions>();
+            var handler = new Handler(mockDatabaseActions.Object);
+            var tableName = "myTable";
+            Environment.SetEnvironmentVariable("DB_TABLE_NAME", tableName);
 
-        //    var bucketData = new S3EventNotification.S3Entity()
-        //    {
-        //        Bucket = new S3EventNotification.S3BucketEntity() { Name = "testBucket" },
-        //        Object = new S3EventNotification.S3ObjectEntity { Key = "test/key.csv" }
-        //    };
-        //    //S3 record mock
-        //    var testRecord = new S3EventNotification.S3EventNotificationRecord();
-        //    testRecord.AwsRegion = "eu-west-2";
-        //    testRecord.S3 = bucketData;
+            var bucketData = new S3EventNotification.S3Entity
+            {
+                Bucket = new S3EventNotification.S3BucketEntity { Name = "testBucket" },
+                Object = new S3EventNotification.S3ObjectEntity { Key = "test/key.csv" }
+            };
 
-        //    var s3EventMock = new S3EventNotification();
-        //    s3EventMock.Records = new List<S3EventNotification.S3EventNotificationRecord> { testRecord };
+            //S3 record mock
+            var testRecord = new S3EventNotification.S3EventNotificationRecord();
+            testRecord.AwsRegion = "eu-west-2";
+            testRecord.S3 = bucketData;
 
-        //    var contextMock = new Mock<ILambdaContext>();
-        //    //set up Database actions
-        //    mockDatabaseActions.Setup(x => x.CopyDataToDatabase(tableName, contextMock.Object, testRecord.AwsRegion, bucketData.Bucket.Name, bucketData.Object.Key));
-        //    mockDatabaseActions.Setup(x => x.TruncateTable(contextMock.Object, It.IsAny<string>()));
-        //    mockDatabaseActions.Setup(x => x.SetupDatabase(contextMock.Object)).Returns(() => new NpgsqlConnection());
+            var s3EventMock = new S3EventNotification();
+            s3EventMock.Records = new List<S3EventNotification.S3EventNotificationRecord> { testRecord };
 
-        //    Assert.DoesNotThrow(() => handler.LoadCsv(s3EventMock, contextMock.Object));
-        //    mockDatabaseActions.Verify(y => y.SetupDatabase(contextMock.Object), Times.Once);
-        //    mockDatabaseActions.Verify(y => y.TruncateTable(contextMock.Object, It.IsAny<string>()), Times.Once);
-        //    mockDatabaseActions.Verify(y => y.CopyDataToDatabase(tableName, contextMock.Object, testRecord.AwsRegion, bucketData.Bucket.Name, bucketData.Object.Key), Times.Once);
-        //}
+            var contextMock = new Mock<ILambdaContext>();
+            //set up Database actions
+            mockDatabaseActions.Setup(x => x.CopyDataToDatabase(tableName, contextMock.Object, testRecord.AwsRegion, bucketData.Bucket.Name, bucketData.Object.Key));
+            mockDatabaseActions.Setup(x => x.TruncateTable(contextMock.Object, It.IsAny<string>()));
+            mockDatabaseActions.Setup(x => x.SetupDatabase(contextMock.Object)).Returns(() => new NpgsqlConnection());
+
+            Assert.DoesNotThrow(() => handler.LoadCsv(s3EventMock, contextMock.Object));
+            mockDatabaseActions.Verify(y => y.SetupDatabase(contextMock.Object), Times.Once);
+            mockDatabaseActions.Verify(y => y.TruncateTable(contextMock.Object, It.IsAny<string>()), Times.Once);
+            mockDatabaseActions.Verify(y => y.CopyDataToDatabase(tableName, contextMock.Object, testRecord.AwsRegion, bucketData.Bucket.Name, bucketData.Object.Key), Times.Once);
+        }
     }
 }
 

--- a/AddressesDataPipeline.Tests/Handler.cs
+++ b/AddressesDataPipeline.Tests/Handler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using AddressDataPipeline.Database;
+using AddressesDataPipeline.Database;
 using Amazon.Lambda.Core;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
@@ -11,7 +11,7 @@ using Moq;
 using Npgsql;
 using NUnit.Framework;
 
-namespace AddressDataPipeline.Tests
+namespace AddressesDataPipeline.Tests
 {
     [TestFixture]
     public class HandlerTest : DatabaseTests

--- a/AddressesDataPipeline/Database/DatabaseActions.cs
+++ b/AddressesDataPipeline/Database/DatabaseActions.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace AddressDataPipeline.Database
+namespace AddressesDataPipeline.Database
 {
     public class DatabaseActions : IDatabaseActions
     {

--- a/AddressesDataPipeline/Database/IDatabaseActions.cs
+++ b/AddressesDataPipeline/Database/IDatabaseActions.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace AddressDataPipeline.Database
+namespace AddressesDataPipeline.Database
 {
     public interface IDatabaseActions
     {

--- a/AddressesDataPipeline/Handler.cs
+++ b/AddressesDataPipeline/Handler.cs
@@ -6,7 +6,7 @@ using Amazon.S3.Util;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Npgsql;
-using AddressDataPipeline.Database;
+using AddressesDataPipeline.Database;
 using System;
 using System.IO;
 using System.Linq;
@@ -17,7 +17,7 @@ using System.Threading;
 [assembly: LambdaSerializer(
     typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
-namespace AddressDataPipeline
+namespace AddressesDataPipeline
 {
     public static class Program
     {

--- a/AddressesDataPipeline/build.cmd
+++ b/AddressesDataPipeline/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/AddressDataPipeline.zip
+dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/AddressesDataPipeline.zip

--- a/AddressesDataPipeline/build.sh
+++ b/AddressesDataPipeline/build.sh
@@ -8,4 +8,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration Debug --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/AddressDataPipeline.zip
+dotnet lambda package --configuration Debug --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/AddressesDataPipeline.zip


### PR DESCRIPTION
The file was called `AddressesAPI` and the namespace `AddressAPI`. Renamed to keep these inline.
Uncommented and fixed Handler test