### PR TITLE
Lambda role name has been changed

### DIFF
--- a/AddressesDataPipeline/serverless.yml
+++ b/AddressesDataPipeline/serverless.yml
@@ -35,7 +35,7 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         Path: /${self:service}/${self:provider.stage}/
-        RoleName: addressesDataPipelineLambdaExecutionRole
+        RoleName: AddressesDataPipelineLambdaExecutionRole
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/AddressesDataPipeline/serverless.yml
+++ b/AddressesDataPipeline/serverless.yml
@@ -35,7 +35,7 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         Path: /${self:service}/${self:provider.stage}/
-        RoleName: dataPipelineLambdaExecutionRole
+        RoleName: addressesDataPipelineLambdaExecutionRole
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:


### PR DESCRIPTION
Lambda Execution role name intially was 'DataPipelineLambdaExecutionRole' but has been changed to 'addressesDataPipelineLambdaExecutionRole'